### PR TITLE
REFACTOR: 게시글 유형별(요청/출동) 조회 구현

### DIFF
--- a/src/main/java/com/example/wonderwoman/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/example/wonderwoman/delivery/controller/DeliveryController.java
@@ -4,6 +4,7 @@ import com.example.wonderwoman.common.dto.NormalResponseDto;
 import com.example.wonderwoman.delivery.DeliveryPostResponseDto;
 import com.example.wonderwoman.delivery.DeliveryResponseDto;
 import com.example.wonderwoman.delivery.entity.DeliveryPost;
+import com.example.wonderwoman.delivery.entity.ReqType;
 import com.example.wonderwoman.delivery.request.DeliveryRequestDto;
 import com.example.wonderwoman.delivery.service.DeliveryService;
 import com.example.wonderwoman.member.entity.Member;
@@ -37,6 +38,7 @@ public class DeliveryController {
 
     @ResponseBody
     public ResponseEntity<List<DeliveryPost>> getAllDeliveryPosts() {
+        System.out.println("GET all delivery posts OK");
         List<DeliveryPost> deliveryPosts = deliveryService.getAllDeliveryPosts();
         return ResponseEntity.ok(deliveryPosts);
     }
@@ -57,18 +59,21 @@ public class DeliveryController {
 //    }
 
     // 딜리버리 게시글 조회 - 유형: 요청
-    @GetMapping(params = "category=request")
+    @GetMapping(value = "/post", params = "category=request")
     @ResponseBody
-    public ResponseEntity<List<DeliveryPost>> getDeliveryPostsByTypeRequest() {
-        List<DeliveryPost> requestDeliveryPosts = deliveryService.getDeliveryPostsByTypeRequest();
-        return ResponseEntity.ok(requestDeliveryPosts);
+    public ResponseEntity<List<DeliveryPost>> getDeliveryPostsByTypeRequest(@RequestParam("category") String category) {
+        if ("request".equals(category)) {
+            List<DeliveryPost> requestDeliveryPosts = deliveryService.getDeliveryPostsByType(ReqType.REQUEST);
+            return ResponseEntity.ok(requestDeliveryPosts);
+        }
+        return null;
     }
 
     // 딜리버리 게시글 조회 - 유형: 출동
-    @GetMapping(params = "category=dispatch")
+    @GetMapping(value = "/post", params = "category=dispatch")
     @ResponseBody
     public ResponseEntity<List<DeliveryPost>> getDeliveryPostsByTypeDispatch() {
-        List<DeliveryPost> dispatchDeliveryPosts = deliveryService.getDeliveryPostsByTypeDispatch();
+        List<DeliveryPost> dispatchDeliveryPosts = deliveryService.getDeliveryPostsByType(ReqType.DISPATCH);
         return ResponseEntity.ok(dispatchDeliveryPosts);
     }
 

--- a/src/main/java/com/example/wonderwoman/delivery/repository/DeliveryPostRepository.java
+++ b/src/main/java/com/example/wonderwoman/delivery/repository/DeliveryPostRepository.java
@@ -1,6 +1,7 @@
 package com.example.wonderwoman.delivery.repository;
 
 import com.example.wonderwoman.delivery.entity.DeliveryPost;
+import com.example.wonderwoman.delivery.entity.ReqType;
 import com.example.wonderwoman.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,5 +13,5 @@ import java.util.List;
 public interface DeliveryPostRepository extends JpaRepository<DeliveryPost, Long> {
 
     // 게시글 유형에 따른 게시물 조회
-    List<DeliveryPost> findByPostReqType(String postReqType);
+    List<DeliveryPost> findByPostReqType(ReqType postReqType);
 }

--- a/src/main/java/com/example/wonderwoman/delivery/service/DeliveryService.java
+++ b/src/main/java/com/example/wonderwoman/delivery/service/DeliveryService.java
@@ -37,14 +37,9 @@ public class DeliveryService {
 //                .collect(Collectors.toList());
 //    }
 
-    // 게시글 조회 - 유형:요청
-    public List<DeliveryPost> getDeliveryPostsByTypeRequest() {
-        return deliveryPostRepository.findByPostReqType(ReqType.REQUEST.getTypeName());
-    }
-
-    // 게시글 조회 - 유형:출동
-    public List<DeliveryPost> getDeliveryPostsByTypeDispatch() {
-        return deliveryPostRepository.findByPostReqType(ReqType.DISPATCH.getTypeName());
+    // 게시글 조회 - 유형: 요청/출동
+    public List<DeliveryPost> getDeliveryPostsByType(ReqType reqType) {
+        return deliveryPostRepository.findByPostReqType(reqType);
     }
 
     // DeliveryPost를 DeliveryPostResponseDto로 변환하는 메서드


### PR DESCRIPTION
## 작업 내용 :technologist:
- 딜리버리 게시글 조회 시, 유형별(요청/출동) 게시글 조회 구현했습니다.

## 반영 브랜치 :rocket:
delivery/givesilverstick -> master

## To Reviewers :speech_balloon:
- 임시로 cofig.WebSecurityConfig 파일 내 '/app/delivery/post' 접근 권한 해제 후 API 테스트 진행하였습니다. 
