### PR TITLE
[FEAT] 게시글 상태 '취소' 추가

### DIFF
--- a/src/main/java/com/example/wonderwoman/chatting/controller/ChatRoomController.java
+++ b/src/main/java/com/example/wonderwoman/chatting/controller/ChatRoomController.java
@@ -10,6 +10,8 @@ import com.example.wonderwoman.chatting.response.ChatRoomListDto;
 import com.example.wonderwoman.chatting.service.ChatService;
 import com.example.wonderwoman.chatting.service.ResponseService;
 import com.example.wonderwoman.common.dto.NormalResponseDto;
+import com.example.wonderwoman.delivery.entity.PostStatus;
+import com.example.wonderwoman.delivery.service.DeliveryService;
 import com.example.wonderwoman.login.CurrentUser;
 import com.example.wonderwoman.member.entity.Member;
 import com.example.wonderwoman.member.repository.MemberRepository;
@@ -28,6 +30,7 @@ public class ChatRoomController {
 
     private static final Logger logger = LoggerFactory.getLogger(ChatRoomController.class);
     private final ChatService chatService;
+    private final DeliveryService deliveryService;
     private final ResponseService responseService;
     private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
@@ -64,8 +67,17 @@ public class ChatRoomController {
     //딜리버리 상태 변경
     @PostMapping("/room/status")
     public ResponseEntity<ChatRoomInfoResponse> updateRoomStatus(@CurrentUser Member member, @RequestBody ChatRoomStatusRequest request) {
-        chatService.updatePostStatus(request.getChatRoomId(), request.getStatus());
-
+//        chatService.updatePostStatus(request.getChatRoomId(), request.getStatus());
+        PostStatus postStatus = deliveryService.findPostStatus(member, request.getPostId());
+        System.out.println(postStatus);
+        if (PostStatus.NONE.equals(postStatus)) {
+            System.out.println("채팅방 존재하지 않을 때");
+            chatService.updatePostStatusWithCancellationByPostId(request.getPostId(), request.getStatus());
+        } else {
+            System.out.println("채팅방 존재할 때");
+            chatService.updatePostStatus(request.getChatRoomId(), request.getStatus());
+            return ResponseEntity.ok(chatService.findRoomById(member, request.getChatRoomId()));
+        }
         return ResponseEntity.ok(chatService.findRoomById(member, request.getChatRoomId()));
     }
 

--- a/src/main/java/com/example/wonderwoman/chatting/request/ChatRoomStatusRequest.java
+++ b/src/main/java/com/example/wonderwoman/chatting/request/ChatRoomStatusRequest.java
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ChatRoomStatusRequest {
     private String chatRoomId;
-
+    private String postId;
     private PostStatus status;
 }

--- a/src/main/java/com/example/wonderwoman/chatting/service/ChatService.java
+++ b/src/main/java/com/example/wonderwoman/chatting/service/ChatService.java
@@ -171,6 +171,22 @@ public class ChatService {
         deliveryPostRepository.save(deliveryPost);
     }
 
+    @Transactional
+    public void updatePostStatusWithCancellationByPostId(String postId, PostStatus postStatus) {
+        DeliveryPost deliveryPost = deliveryPostRepository.findById(postId)
+                .orElseThrow(() -> new WonderException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        // 이미 '없음' 상태인 경우에는 게시글 상태를 postStatus로 변경
+        if (deliveryPost.getPostStatus() == PostStatus.NONE) {
+            deliveryPost.updatePostStatus(postStatus);
+            deliveryPostRepository.save(deliveryPost);
+        } else {
+            throw new WonderException(ErrorCode.INVALID_POST_STATUS_CHANGE);
+        }
+    }
+
+
+
     //채팅방 삭제(퇴장)
     @Transactional
     public void deleteById(Member member, String chatRoomId) {

--- a/src/main/java/com/example/wonderwoman/delivery/entity/DeliveryPost.java
+++ b/src/main/java/com/example/wonderwoman/delivery/entity/DeliveryPost.java
@@ -72,6 +72,10 @@ public class DeliveryPost extends BaseTimeEntity {
         this.postComment = postComment;
         this.member = member;
 
+
+    }
+    public PostStatus getStatus() {
+        return postStatus;
     }
 
     public boolean isWrittenPost(Member member) {

--- a/src/main/java/com/example/wonderwoman/delivery/entity/PostStatus.java
+++ b/src/main/java/com/example/wonderwoman/delivery/entity/PostStatus.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public enum PostStatus {
     NONE("없음"),
+    CANCEL("취소"),
     CHATTING("채팅중"),
     IN_PROGRESS("진행중"),
     DONE("완료");

--- a/src/main/java/com/example/wonderwoman/delivery/repository/DeliveryPostRepository.java
+++ b/src/main/java/com/example/wonderwoman/delivery/repository/DeliveryPostRepository.java
@@ -4,9 +4,12 @@ import com.example.wonderwoman.delivery.entity.DeliveryPost;
 import com.example.wonderwoman.delivery.entity.ReqType;
 import com.example.wonderwoman.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @Repository
@@ -14,4 +17,8 @@ public interface DeliveryPostRepository extends JpaRepository<DeliveryPost, Long
 
     // 게시글 유형에 따른 게시물 조회
     List<DeliveryPost> findByPostReqType(ReqType postReqType);
+
+    Optional<DeliveryPost> findByIdAndMember(Long id, Member member);
+    @Query("select c from DeliveryPost c where c.id=:id")
+    Optional<DeliveryPost> findById(@Param("id") String id);
 }

--- a/src/main/java/com/example/wonderwoman/delivery/service/DeliveryService.java
+++ b/src/main/java/com/example/wonderwoman/delivery/service/DeliveryService.java
@@ -63,6 +63,11 @@ public class DeliveryService {
         return deliveryRepositoryImpl.getSliceOfDelivery(member, reqType, school, buildings, sanitarySizes, lastId, pageable);
     }
 
-
+    // 게시글 상태 조회
+    public PostStatus findPostStatus(Member member, String postId) {
+        DeliveryPost deliveryPost = deliveryPostRepository.findByIdAndMember(Long.valueOf(postId), member)
+                .orElseThrow(() -> new RuntimeException("해당하는 게시글을 찾을 수 없습니다."));
+        return deliveryPost.getStatus();
+    }
 
 }

--- a/src/main/java/com/example/wonderwoman/delivery/service/DeliveryService.java
+++ b/src/main/java/com/example/wonderwoman/delivery/service/DeliveryService.java
@@ -2,6 +2,7 @@ package com.example.wonderwoman.delivery.service;
 
 import com.example.wonderwoman.delivery.entity.Building;
 import com.example.wonderwoman.delivery.entity.DeliveryPost;
+import com.example.wonderwoman.delivery.entity.PostStatus;
 import com.example.wonderwoman.delivery.entity.SanitarySize;
 import com.example.wonderwoman.delivery.repository.DeliveryPostRepository;
 import com.example.wonderwoman.delivery.repository.DeliveryRepositoryImpl;

--- a/src/main/java/com/example/wonderwoman/exception/ErrorCode.java
+++ b/src/main/java/com/example/wonderwoman/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "글을 찾지 못했습니다.", "존재하는 글인지 확인해주세요."),
     FORBIDDEN_CHATROOM(HttpStatus.FORBIDDEN, "채팅방에 접근 권한이 없습니다.", "채팅방에 참여하는 회원인지 확인해주세요."),
     ARTICLE_CAN_NOT_DELETE(HttpStatus.FORBIDDEN, "이미 진행중인 글입니다.", "어떠한 상태도 없는 글인지 확인해주세요."),
-    BUILDING_NOT_MATCH(HttpStatus.BAD_REQUEST, "건물이 학교와 매칭되지 않습니다.", "건물을 올바르게 선택해주세요.");
+    BUILDING_NOT_MATCH(HttpStatus.BAD_REQUEST, "건물이 학교와 매칭되지 않습니다.", "건물을 올바르게 선택해주세요."),
+    INVALID_POST_STATUS_CHANGE(HttpStatus.BAD_REQUEST, "현재 딜리버리 상태에서는 상태 변경이 불가능합니다.", "딜리버리 상태가 '없음'인 경우에만 취소 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 작업 내용 :technologist:
- 게시글 상태 '취소' 추가하여 채팅방 상태 변경 api에서 취소로 변경할 수 있습니다.
- 채팅방 상태 변경 request에 postId 추가하였습니다.
- postId가 '없음'일 경우(채팅방 존재 X)에만 게시글 상태 변경 가능합니다. (채팅방이 존재하면, 기존대로 채팅방 상태 변경 가능)

## 반영 브랜치 :rocket:
chatting/givesilverstick -> master

## To Reviewers :speech_balloon:
- api 테스트 완료했는데, postId의 상태가 '없음'이기만 하면 404 에러가 뜨더라도 상태 변경은 잘 됩니다. (수정하겠습니다)
- 채팅방이 없는 (게시글 상태가 '없음')인 경우 request로 postId와 status 만 줘도 됩니다.
- 채팅방이 있는 경우 request로 postId, status 그리고 chatRoomId까지 줘야 됩니다.
